### PR TITLE
Correction of bug

### DIFF
--- a/src/vstsbuildstatus.ts
+++ b/src/vstsbuildstatus.ts
@@ -140,14 +140,17 @@ export class VstsBuildStatus {
     public openQueueBuildSelection(): void {
         this.getBuildDefinitionByQuickPick("Select a build definition").then(result => {
             if (!result) {
-                return;
+                return Promise.reject(null);
             }
 
             return this.restClient.queueBuild(result);
         }).then(result => {
             window.showInformationMessage(`Build has been queued for ${result.value.definition.name}`);
         }, error => {
-            this.handleError();
+            if(error) {
+                this.handleError();
+            }
+            // Otherwise has been cancelled by the user
         });
     }
 


### PR DESCRIPTION
An exception was thrown because the result wasn't properly handle when the user didn't choose  a build to queue (by pressins on « ESC » or click outside of the dropdown selection).