### PR TITLE
Ability to group several build definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,14 @@ The extension is enabled by providing the following settings (user or workspace)
 }
 ```
 
+It also allows to add several build definitions grouped into one status bar indicator. It could be helpful if you trigger multiple builds which overall result is success only if all builds are passing (e.g. when running multiple build definitions on the same code base cross-platform). To enable grouped build definitions, add the following configuration in addition to the one at the top:
+
+```json
+{
+    "vsts.definitionsGroup": "1,2,3", // IDs of build definitions to be grouped, separated with a comma
+    "vsts.definitionsGroupName": "My Grouped Builds", // Name of the grouped build definitions
+}
+```
+
 ## License
 MIT, please see LICENSE for details. Copyright (c) 2016 Jeppe Andersen.

--- a/package.json
+++ b/package.json
@@ -73,6 +73,16 @@
                     "type": "string",
                     "default": "",
                     "description": "Specifies the VSTS project to look for builds in."
+                },
+                "vsts.definitionsGroup": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Allows to group status of the several build definitions by IDs (e.g. '1,2,3')."
+                },
+                "vsts.definitionsGroupName": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Allows to provide name for grouped build definitions."
                 }
             }
         },

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -64,7 +64,7 @@ export class WorkspaceVstsSettings implements Settings {
     }
 
     public isValid(): boolean {
-        return this.isAccountProvided() && this.isCredentialsProvided() && this.isProjectSpecified();
+        return this.isAccountProvided() && this.isCredentialsProvided() && this.isProjectSpecified() && this.isBuildDefinitionsNameSpecified();
     }
 
     public dispose(): void {
@@ -98,7 +98,7 @@ export class WorkspaceVstsSettings implements Settings {
     }
 
     private isBuildDefinitionsNameSpecified(): boolean {
-        if (this.activeBuildDefinitions.length > 1 && !this.definitionsGroupName) {
+        if (this.definitionsGroup && !this.definitionsGroupName) {
             return false;
         }
 
@@ -113,11 +113,11 @@ export class WorkspaceVstsSettings implements Settings {
         this.password = configuration.get<string>("password").trim();
         this.project = configuration.get<string>("project").trim();
 
-        const defsGroup = configuration.get<string>("definitionsGroup").trim();
+        const definitionsGroup = configuration.get<string>("definitionsGroup").trim();
         this.definitionsGroupName = configuration.get<string>("definitionsGroupName").trim();
         
-        if (defsGroup) {
-            const buildIds = defsGroup.split(',').map(id => parseInt(id));
+        if (definitionsGroup) {
+            const buildIds = definitionsGroup.split(',').map(id => parseInt(id));
             let defList = [];
             buildIds.forEach(id => {
                 defList.push({

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -118,12 +118,12 @@ export class WorkspaceVstsSettings implements Settings {
         
         if (definitionsGroup) {
             const buildIds = definitionsGroup.split(',').map(id => parseInt(id));
-            let defList = [];
+            let defList: BuildDefinition[] = [];
             buildIds.forEach(id => {
                 defList.push({
                     id: id,
                     name: this.definitionsGroupName,
-                    revision: 0
+                    revision: undefined
                 });
             });
             this.definitionsGroup = defList;            

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -8,7 +8,9 @@ export interface Settings {
     username: string;
     password: string;
     project: string;
-    activeBuildDefinition: BuildDefinition;
+    activeBuildDefinitions: BuildDefinition[];
+    definitionsGroup?: BuildDefinition[];
+    definitionsGroupName?: string;
     onDidChangeSettings(handler: () => void): void;
 
     dispose(): void;
@@ -20,9 +22,11 @@ export class WorkspaceVstsSettings implements Settings {
     username: string;
     password: string;
     project: string;
+    definitionsGroup?: BuildDefinition[];
+    definitionsGroupName?: string;
 
-    private _activeBuildDefinition: BuildDefinition;
-    private activeBuildDefinitionStateKey: string = "vsts.active.definition";
+    private _activeBuildDefinitions: BuildDefinition[] = [];
+    private activeBuildDefinitionsStateKey: string = "vsts.active.definitions";
     private state: Memento;
     private workspaceSettingsChangedDisposable: Disposable;
     private onDidChangeSettingsHandler: () => any;
@@ -30,9 +34,9 @@ export class WorkspaceVstsSettings implements Settings {
     constructor(state: Memento) {
         this.state = state;
 
-        var definition = state.get<BuildDefinition>(this.activeBuildDefinitionStateKey);
-        if (definition) {
-            this.activeBuildDefinition = definition;
+        var definitions = state.get<BuildDefinition[]>(this.activeBuildDefinitionsStateKey);
+        if (definitions) {
+            this.activeBuildDefinitions = definitions;
         }
 
         this.workspaceSettingsChangedDisposable = workspace.onDidChangeConfiguration(() => {
@@ -46,13 +50,13 @@ export class WorkspaceVstsSettings implements Settings {
         this.reload();
     }
     
-    get activeBuildDefinition(): BuildDefinition {
-        return this._activeBuildDefinition;
+    get activeBuildDefinitions(): BuildDefinition[] {
+        return this._activeBuildDefinitions;
     }
 
-    set activeBuildDefinition(definition: BuildDefinition) {
-        this._activeBuildDefinition = definition;
-        this.state.update(this.activeBuildDefinitionStateKey, definition);
+    set activeBuildDefinitions(definitions: BuildDefinition[]) {
+        this._activeBuildDefinitions = definitions;
+        this.state.update(this.activeBuildDefinitionsStateKey, definitions);
     }
 
     public onDidChangeSettings(handler: () => any): void {
@@ -93,6 +97,14 @@ export class WorkspaceVstsSettings implements Settings {
         return false;
     }
 
+    private isBuildDefinitionsNameSpecified(): boolean {
+        if (this.activeBuildDefinitions.length > 1 && !this.definitionsGroupName) {
+            return false;
+        }
+
+        return true;
+    }
+
     private reload() {
         var configuration = workspace.getConfiguration("vsts");
 
@@ -100,5 +112,22 @@ export class WorkspaceVstsSettings implements Settings {
         this.username = configuration.get<string>("username").trim();
         this.password = configuration.get<string>("password").trim();
         this.project = configuration.get<string>("project").trim();
+
+        const defsGroup = configuration.get<string>("definitionsGroup").trim();
+        this.definitionsGroupName = configuration.get<string>("definitionsGroupName").trim();
+        
+        if (defsGroup) {
+            const buildIds = defsGroup.split(',').map(id => parseInt(id));
+            let defList = [];
+            buildIds.forEach(id => {
+                defList.push({
+                    id: id,
+                    name: this.definitionsGroupName,
+                    revision: 0
+                });
+            });
+            this.definitionsGroup = defList;            
+            this.activeBuildDefinitions = defList;
+        }
     }
 }

--- a/src/vstsbuildrestclient.ts
+++ b/src/vstsbuildrestclient.ts
@@ -60,8 +60,7 @@ export class VstsBuildRestClientFactoryImpl implements VstsBuildRestClientFactor
 }
 
 export interface VstsBuildRestClient {
-    getLatest(definition: BuildDefinition): Thenable<HttpResponse<Build>>;
-    getBuilds(definition: BuildDefinition, take: number): Thenable<HttpResponse<Build[]>>;
+    getBuilds(definitions: BuildDefinition[], take: number): Thenable<HttpResponse<Build[]>>;
     getBuild(buildId: number): Thenable<HttpResponse<Build>>;
     getLog(build: Build): Thenable<HttpResponse<BuildLog>>;
     getDefinitions(): Thenable<HttpResponse<BuildDefinition[]>>;
@@ -78,18 +77,8 @@ class VstsBuildRestClientImpl implements VstsBuildRestClient {
         this.client = new rest.Client();
     }
 
-    public getLatest(definition: BuildDefinition): Thenable<HttpResponse<Build>> {
-        return this.getBuilds(definition, 1).then(result => {
-            if (result.value.length > 0) {
-                return new HttpResponse(200, result.value[0]);
-            }
-
-            return VstsBuildRestClientImpl.emptyHttpResponse;
-        });
-    }
-
-    public getBuilds(definition: BuildDefinition, take: number = 5): Thenable<HttpResponse<Build[]>> {
-        let url = `https://${this.settings.account}.visualstudio.com/DefaultCollection/${this.settings.project}/_apis/build/builds?definitions=${definition.id}&$top=${take}&api-version=2.0`;
+    public getBuilds(definitions: BuildDefinition[], take: number = 5): Thenable<HttpResponse<Build[]>> {
+        let url = `https://${this.settings.account}.visualstudio.com/DefaultCollection/${this.settings.project}/_apis/build/builds?definitions=${definitions.map(d => d.id).join(',')}&$top=${take}&api-version=2.0`;
 
         return this.getMany<Build[]>(url).then(response => {
             if (response.value && response.value.length > 0) {

--- a/src/vstsbuildstatus.ts
+++ b/src/vstsbuildstatus.ts
@@ -64,7 +64,7 @@ export class VstsBuildStatus {
         }
 
         if (!this.activeDefinition) {
-            this.statusBar.displayInformation("Select build definition", "");
+            this.statusBar.displayInformation("Select build definition");
 
             return;
         }

--- a/src/vstsbuildstatus.ts
+++ b/src/vstsbuildstatus.ts
@@ -9,10 +9,10 @@ import fs = require("fs");
 import openurl = require("openurl");
 
 interface BuildDefinitionQuickPickItem {
-    id: number;
+    ids: number[];
     label: string;
     description: string;
-    definition: BuildDefinition;
+    definitions: BuildDefinition[];
 }
 
 interface BuildQuickPickItem {
@@ -26,18 +26,17 @@ export class VstsBuildStatus {
     private updateIntervalInSeconds = 15;
     private statusBar: VstsBuildStatusBar;
 
-    private activeDefinition: BuildDefinition;
+    private activeDefinitions: BuildDefinition[];
     private settings: Settings;
     private intervalTimer: NodeJS.Timer;
     private restClient: VstsBuildRestClient;
     private logStreamHandler: VstsBuildLogStreamHandler;
 
-
     constructor(settings: Settings, restClientFactory: VstsBuildRestClientFactory) {
         this.settings = settings;
         this.statusBar = new VstsBuildStatusBar();
         this.restClient = restClientFactory.createClient(settings);
-        this.activeDefinition = settings.activeBuildDefinition;
+        this.activeDefinitions = settings.activeBuildDefinitions;
         this.logStreamHandler = new VstsBuildLogStreamHandler(this.restClient);
 
         this.settings.onDidChangeSettings(() => {
@@ -63,26 +62,37 @@ export class VstsBuildStatus {
             return;
         }
 
-        if (!this.activeDefinition) {
-            this.statusBar.displayInformation("Select build definition");
-
+        if (!this.activeDefinitions) {
+            this.statusBar.displayInformation("Select a single build definition or set an aggregated list of IDs in settings");
             return;
         }
 
-        this.restClient.getLatest(this.activeDefinition).then(
+        this.restClient.getBuilds(this.activeDefinitions, this.activeDefinitions.length).then(
             response => {
+                const definitionName = this.settings.definitionsGroupName && this.activeDefinitions.length > 1 ? this.settings.definitionsGroupName : this.activeDefinitions[0].name;
+
                 if (!response.value) {
-                    this.statusBar.displayNoBuilds(this.activeDefinition.name, "No builds found");
+                    this.statusBar.displayNoBuilds(definitionName, "No builds found");
+                    return;
                 }
 
-                if (response.value && response.value.result) {
-                    if (response.value.result === "succeeded") {
-                        this.statusBar.displaySuccess(this.activeDefinition.name, "Last build was completed successfully");
-                    } else {
-                        this.statusBar.displayError(this.activeDefinition.name, "Last build failed");
+                let succeeded = true; // 0 failed, 1 succeeded, 2 in progress
+                for (let build of response.value) {
+                    if (build.result) {
+                        if (build.result !== "succeeded") {
+                            this.statusBar.displayError(definitionName, "Last build failed");
+                            succeeded = false;
+                            break;
+                        }
+                    } else if (response.value) {
+                        this.statusBar.displayLoading(definitionName, "Build in progress...");
+                        succeeded = false;
+                        break;
                     }
-                } else if (response.value) {
-                    this.statusBar.displayLoading(this.activeDefinition.name, "Build in progress...");
+                }
+
+                if (succeeded) {
+                    this.statusBar.displaySuccess(definitionName, "Last build was completed successfully");
                 }
 
                 this.tryStartPeriodicStatusUpdate();
@@ -94,8 +104,8 @@ export class VstsBuildStatus {
     public openBuildDefinitionSelection(): void {
         this.getBuildDefinitionByQuickPick("Select a build definition to monitor").then(result => {
             if (result) {
-                this.activeDefinition = result;
-                this.settings.activeBuildDefinition = this.activeDefinition;
+                this.activeDefinitions = result;
+                this.settings.activeBuildDefinitions = this.activeDefinitions;
                 this.updateStatus();
             }
         }, error => {
@@ -108,8 +118,12 @@ export class VstsBuildStatus {
             if (!result) {
                 return;
             }
+            if (result.length > 1) {
+                window.showInformationMessage(`Group build definition cannot be opened, please select single one instead.`);
+                return;
+            }
 
-            return this.getBuildByQuickPick(result, "Select a build to open");
+            return this.getBuildByQuickPick(result[0], "Select a build to open");
         }).then(build => {
             if (!build) {
                 return;
@@ -124,8 +138,12 @@ export class VstsBuildStatus {
             if (!result) {
                 return;
             }
+            if (result.length > 1) {
+                window.showInformationMessage(`Viewing group build is not possible, please select single build instead.`);
+                return;
+            }
 
-            return this.getBuildByQuickPick(result, "Select a build to view");
+            return this.getBuildByQuickPick(result[0], "Select a build to view");
         }).then(build => {
             if (!build) {
                 return;
@@ -142,14 +160,18 @@ export class VstsBuildStatus {
             if (!result) {
                 return Promise.reject(null);
             }
+            if (result.length > 1) {
+                window.showInformationMessage(`Queueing group build is not possible, please queue single builds one-by-one instead.`);
+                return Promise.reject(null);;
+            }
 
             return window.showInputBox({prompt: "Branch (leave empty to use default) ?"}).then(branch => {
                 if(branch !== undefined) {
                     if(branch.length !== 0) {
-                        result.sourceBranch = branch;
+                        result[0].sourceBranch = branch;
                     }
 
-                    return this.restClient.queueBuild(result);
+                    return this.restClient.queueBuild(result[0]);
                 }
                 else {
                     // The user has cancel the input box
@@ -166,7 +188,7 @@ export class VstsBuildStatus {
         });
     }
 
-    private getBuildDefinitionByQuickPick(placeHolder: string): Thenable<BuildDefinition> {
+    private getBuildDefinitionByQuickPick(placeHolder: string): Thenable<BuildDefinition[]> {
         if (!this.settings.isValid()) {
             this.showSettingsMissingMessage();
 
@@ -179,10 +201,19 @@ export class VstsBuildStatus {
                     return {
                         label: definition.name,
                         description: `Revision ${definition.revision}`,
-                        id: definition.id,
-                        definition: definition
+                        ids: [definition.id],
+                        definitions: [definition]
                     }
                 });
+
+                if (this.settings.definitionsGroup) {
+                    buildDefinitions.push({
+                            label: this.settings.definitionsGroupName ? this.settings.definitionsGroupName : this.settings.definitionsGroup.map(b => b.id.toString()).join(','),
+                            description: 'Group Build Definition',
+                            ids: this.settings.definitionsGroup.map(b => b.id),
+                            definitions: this.settings.definitionsGroup
+                    });
+                }
 
                 let options = {
                     placeHolder: placeHolder
@@ -190,7 +221,7 @@ export class VstsBuildStatus {
 
                 window.showQuickPick(buildDefinitions, options).then(result => {
                     if (result) {
-                        resolve(result.definition);
+                        resolve(result.definitions);
                     } else {
                         resolve(null);
                     }
@@ -202,7 +233,7 @@ export class VstsBuildStatus {
     }
 
     private getBuildByQuickPick(definition: BuildDefinition, placeHolder: string): Thenable<Build> {
-        return this.restClient.getBuilds(definition, 10).then(builds => {
+        return this.restClient.getBuilds([definition], 10).then(builds => {
             let buildQuickPickItems: BuildQuickPickItem[] = builds.value.map(build => {
                 return {
                     label: new Date(build.queueTime).toLocaleString(),

--- a/src/vstsbuildstatus.ts
+++ b/src/vstsbuildstatus.ts
@@ -62,7 +62,7 @@ export class VstsBuildStatus {
             return;
         }
 
-        if (!this.activeDefinitions) {
+        if (!this.activeDefinitions || this.activeDefinitions.length < 1) {
             this.statusBar.displayInformation("Select a single build definition or set an aggregated list of IDs in settings");
             return;
         }

--- a/src/vstsbuildstatus.ts
+++ b/src/vstsbuildstatus.ts
@@ -209,7 +209,7 @@ export class VstsBuildStatus {
                 if (this.settings.definitionsGroup) {
                     buildDefinitions.push({
                             label: this.settings.definitionsGroupName ? this.settings.definitionsGroupName : this.settings.definitionsGroup.map(b => b.id.toString()).join(','),
-                            description: 'Grouped Build Definitions',
+                            description: 'Grouped Build Definition',
                             ids: this.settings.definitionsGroup.map(b => b.id),
                             definitions: this.settings.definitionsGroup
                     });

--- a/src/vstsbuildstatus.ts
+++ b/src/vstsbuildstatus.ts
@@ -53,7 +53,7 @@ export class VstsBuildStatus {
 
     public updateStatus(): void {
         // Updates the status bar depending on the state. 
-        // If everything goes well, the method ißs set up to be called periodically.
+        // If everything goes well, the method is set up to be called periodically.
 
         if (!this.settings.isValid()) {
             this.tryCancelPeriodicStatusUpdate();
@@ -76,7 +76,7 @@ export class VstsBuildStatus {
                     return;
                 }
 
-                let succeeded = true; // 0 failed, 1 succeeded, 2 in progress
+                let succeeded = true;
                 for (let build of response.value) {
                     if (build.result) {
                         if (build.result !== "succeeded") {
@@ -209,7 +209,7 @@ export class VstsBuildStatus {
                 if (this.settings.definitionsGroup) {
                     buildDefinitions.push({
                             label: this.settings.definitionsGroupName ? this.settings.definitionsGroupName : this.settings.definitionsGroup.map(b => b.id.toString()).join(','),
-                            description: 'Group Build Definition',
+                            description: 'Grouped Build Definitions',
                             ids: this.settings.definitionsGroup.map(b => b.id),
                             definitions: this.settings.definitionsGroup
                     });

--- a/src/vstsbuildstatusbar.ts
+++ b/src/vstsbuildstatusbar.ts
@@ -6,27 +6,27 @@ export class VstsBuildStatusBar {
     private statusBarItem: StatusBarItem;
 
     public displaySuccess(text: string, tooltip: string): void {
-        this.displayStatusBarItem(text, tooltip, "octicon-check", "extension.openVstsBuildDefinitionSelection");
+        this.displayStatusBarItem(text, tooltip, "octicon-check");
     }
 
     public displayLoading(text: string, tooltip: string): void {
-        this.displayStatusBarItem(text, tooltip, "octicon-sync", "extension.openVstsBuildDefinitionSelection");
+        this.displayStatusBarItem(text, tooltip, "octicon-sync");
     }
 
     public displayError(text: string, tooltip: string): void {
-        this.displayStatusBarItem(text, tooltip, "octicon-alert", "extension.openVstsBuildDefinitionSelection");
+        this.displayStatusBarItem(text, tooltip, "octicon-alert");
     }
 
-    public displayInformation(text: string, tooltip: string): void {
-        this.displayStatusBarItem(text, tooltip, "", "extension.openVstsBuildSelection");
+    public displayInformation(text: string, tooltip?: string): void {
+        this.displayStatusBarItem(text, tooltip);
     }
 
     public displayNoBuilds(text: string, tooltip: string): void {
-        this.displayStatusBarItem(text, tooltip, "octicon-clock", "extension.openVstsBuildDefinitionSelection");
+        this.displayStatusBarItem(text, tooltip, "octicon-clock");
     }
 
     public displayConnectivityError(text: string, tooltip: string): void {
-        this.displayStatusBarItem(text, tooltip, "octicon-zap", "extension.openVstsBuildDefinitionSelection");
+        this.displayStatusBarItem(text, tooltip, "octicon-zap");
     }
 
     public hideStatusBarItem() {
@@ -39,7 +39,7 @@ export class VstsBuildStatusBar {
         this.statusBarItem.dispose();
     }
 
-    private displayStatusBarItem(text: string, tooltip: string, icon: string, command: string) {
+    private displayStatusBarItem(text: string, tooltip: string, icon?: string) {
         if (!this.statusBarItem) {
             this.statusBarItem = window.createStatusBarItem(StatusBarAlignment.Left);
         }
@@ -50,8 +50,10 @@ export class VstsBuildStatusBar {
             this.statusBarItem.text = `VSTS Build: ${text}`;
         }
 
-        this.statusBarItem.tooltip = tooltip;
-        this.statusBarItem.command = command;
+        if (tooltip) {
+            this.statusBarItem.tooltip = tooltip;
+        }
+        this.statusBarItem.command = 'extension.openVstsBuildDefinitionSelection';
         this.statusBarItem.show();
     }
 }


### PR DESCRIPTION
As part of work on automating smoke tests for VS Code and creating build definitions to run them scheduled (see https://github.com/Microsoft/vscode/issues/28586 and https://github.com/Microsoft/vscode/issues/27845) I found your extension that provides capabilities we want to use in our dev work - such as seeing status of the builds in the status bar. I'd like to thank you for building it!

One missing piece was that you cannot group build definitions in a single status indicator. We have the following scenario which made me to do this PR:

- We have build definition per each platform we run a smoke test on (Windows, Linux, OS X)
- If any of the builds failed, we would like to see it in the status bar indicator.

Hence, I forked your extension and worked on some amends that required to enable grouped build. I also did little cosmetic changes in `vstsbuildstatusbar.ts`.

It would be great if you can merge those in, however if you feel that this functionality is out of scope for your extension, then I will publish a separate extension, mentioning that it is a fork of yours. Let me know what is more acceptable for you 🙂 

Thank you.
