### PR TITLE
Monitor single build per definition in grouped defs

### DIFF
--- a/src/vstsbuildrestclient.ts
+++ b/src/vstsbuildrestclient.ts
@@ -79,6 +79,9 @@ class VstsBuildRestClientImpl implements VstsBuildRestClient {
 
     public getBuilds(definitions: BuildDefinition[], take: number = 5): Thenable<HttpResponse<Build[]>> {
         let url = `https://${this.settings.account}.visualstudio.com/DefaultCollection/${this.settings.project}/_apis/build/builds?definitions=${definitions.map(d => d.id).join(',')}&$top=${take}&api-version=2.0`;
+        if (definitions.length > 1) { // Return single build per definition, if grouped build definitions were queried
+            url += `&maxBuildsPerDefinition=1`;
+        }
 
         return this.getMany<Build[]>(url).then(response => {
             if (response.value && response.value.length > 0) {


### PR DESCRIPTION
Fixes #14.

Sorry, my bad in previous PR. Expected that `$top` in VSTS build query will pick up most top for each ID of `definitions`.